### PR TITLE
Alteration to OroRequirements.php related to Node

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,11 @@ curl -s https://getcomposer.org/installer | php
 git clone http://github.com/orocrm/crm-application.git
 ```
 
-
-- Make sure that you have [NodeJS][4] installed
+- Make sure that you have [NodeJS][5] installed or another Js Engine eg. Rhino. (If using NodeJS and Ubuntu ensure you set the config.yml with the following).
+```
+oro_require_js:
+    js_engine:                "nodejs"
+```
 
 - Install OroCRM dependencies with composer. If installation process seems too slow you can use "--prefer-dist" option.
   Go to crm-application folder and run composer installation:

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ curl -s https://getcomposer.org/installer | php
 git clone http://github.com/orocrm/crm-application.git
 ```
 
-- Make sure that you have [NodeJS][5] installed or another Js Engine eg. Rhino. (If using NodeJS and Ubuntu ensure you set the config.yml with the following).
+- Make sure that you have [NodeJS][4] installed or another Js Engine eg. Rhino. (If using NodeJS and Ubuntu ensure you set the config.yml with the following).
 ```
 oro_require_js:
     js_engine:                "nodejs"


### PR DESCRIPTION
Alteration to check requirements for node(default) or what is in config

Detect whether a js engine is installed rather then just "node" based on the config settings
Update to the README.md to show below yaml for Ubuntu installs
```
oro_require_js:
    js_engine:  "nodejs"
```
This allows the checks to pass if an alternate js_engine is installed