### PR TITLE
Require Use of HTTPS in Default Security Config

### DIFF
--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -72,5 +72,5 @@ security:
             anonymous:                      false
 
     access_control:
-        - { path: ^/admin/, role: ROLE_ADMIN }
-        - { path: ^/api/rest/(latest|v1)/pinbars, role: ROLE_USER }
+        - { path: ^/admin/, role: ROLE_ADMIN, requires_channel: https }
+        - { path: ^/api/rest/(latest|v1)/pinbars, role: ROLE_USER, requires_channel: https }


### PR DESCRIPTION
This should really be a configurable setting which the system either:

a) picks up on from the base URL set when installing, or;

b) asks you if you want to use secure URLs upon installation

It disappointed me to find that I had to research how the ACL worked to simply setup on a secure URL. Needs to be simpler.